### PR TITLE
Debug latest feature not working

### DIFF
--- a/src/Schematic/ComponentParameterEditor.vbs
+++ b/src/Schematic/ComponentParameterEditor.vbs
@@ -16,10 +16,18 @@ ModuleName = "ComponentParameterEditor.vbs"
 ' @brief        Main entry point that calls the Pascal script
 ' @param        DummyVar        Dummy variable, not used
 Sub ComponentParameterEditor(DummyVar)
-    ' Call the Pascal script's main procedure
-    ' The Pascal script should be compiled and available in Altium's script system
-    ' Using the relative path from the project root
-    RunScriptFile "src\Schematic\ComponentParameterEditor.pas", "LaunchParameterEditor"
+    ' Note: Dans Altium, il n'est pas possible d'appeler directement un script Pascal depuis VBScript
+    ' Le script Pascal doit être enregistré dans le projet de scripts Altium
+    ' Pour utiliser cette fonctionnalité, vous devez :
+    ' 1. Ajouter ComponentParameterEditor.pas au projet de scripts Altium
+    ' 2. Compiler le projet
+    ' 3. Lancer directement "LaunchParameterEditor" depuis le menu Run Script d'Altium
+    
+    ShowMessage("Pour utiliser l'éditeur de paramètres de composants :" & vbCrLf & vbCrLf & _
+                "1. Assurez-vous que ComponentParameterEditor.pas est ajouté au projet de scripts" & vbCrLf & _
+                "2. Compilez le projet (clic droit > Compile)" & vbCrLf & _
+                "3. Lancez 'LaunchParameterEditor' depuis DXP > Run Script" & vbCrLf & vbCrLf & _
+                "Ou appelez directement la procédure depuis le script Pascal.")
 End Sub
 
 ' Alternative entry point for direct access

--- a/src/Schematic/README_ComponentParameterEditor.md
+++ b/src/Schematic/README_ComponentParameterEditor.md
@@ -1,0 +1,59 @@
+# Éditeur de Paramètres de Composants
+
+## Description
+L'éditeur de paramètres de composants est un outil pour Altium Designer qui permet de parcourir et éditer facilement les paramètres Manufacturer et Manufacturer_PN dans une bibliothèque schématique.
+
+## Fonctionnalités
+- Navigation entre les composants d'une bibliothèque
+- Édition des paramètres Manufacturer et Manufacturer_PN
+- Détection automatique des variantes d'orthographe (MFG, MFR, MPN, etc.)
+- Correction automatique des noms de paramètres mal orthographiés
+- Filtrage pour afficher uniquement les composants incomplets
+- Rapport des paramètres manquants ou mal orthographiés
+
+## Installation et Configuration
+
+### Méthode 1: Utilisation directe du script Pascal
+1. Ouvrez votre projet de scripts Altium
+2. Ajoutez le fichier `ComponentParameterEditor.pas` au projet
+3. Compilez le projet (clic droit > Compile)
+4. Ouvrez une bibliothèque schématique (.SchLib)
+5. Allez dans DXP > Run Script
+6. Sélectionnez `LaunchParameterEditor` et cliquez sur Run
+
+### Méthode 2: Intégration dans Script Central
+Le fichier `ComponentParameterEditor.vbs` affiche actuellement un message d'instruction car il n'est pas possible d'appeler directement un script Pascal depuis VBScript dans Altium.
+
+## Utilisation
+1. **Ouvrir une bibliothèque**: Assurez-vous d'avoir une bibliothèque schématique ouverte
+2. **Lancer l'éditeur**: Exécutez `LaunchParameterEditor`
+3. **Navigation**: Utilisez les boutons Précédent/Suivant pour parcourir les composants
+4. **Édition**: Modifiez les valeurs dans les champs Manufacturer et Manufacturer_PN
+5. **Sauvegarde**: Cliquez sur Sauvegarder pour enregistrer les modifications
+6. **Auto-correction**: Utilisez le bouton Auto-Corriger pour standardiser les noms de paramètres
+
+## Variantes reconnues
+### Manufacturer
+- MANUFACTURER
+- MANUFACT
+- MANUF
+- MFG
+- MFR
+- VENDOR
+- FABRICANT
+
+### Manufacturer_PN
+- MANUFACTURER_PN
+- MANUFACTURER_PART_NUMBER
+- MANUFACT_PN
+- MANUF_PN
+- MFG_PN
+- MFR_PN
+- MPN
+- PART_NUMBER
+- PN
+
+## Notes importantes
+- Le script détecte automatiquement les variantes et les affiche avec un fond rouge clair
+- La fonction Auto-Corriger standardise les noms en "Manufacturer" et "Manufacturer_PN"
+- Les modifications sont appliquées directement dans la bibliothèque


### PR DESCRIPTION
Update `ComponentParameterEditor.vbs` to provide instructions for launching the Pascal script directly in Altium, fixing the "RunScriptFile" error.

The Altium VBScript API does not support directly calling Pascal scripts using `RunScriptFile`. The Pascal script must be added to the Altium script project and launched via DXP > Run Script. The VBScript now guides the user on this process, and a new README provides detailed setup and usage instructions.

---
<a href="https://cursor.com/background-agent?bcId=bc-361e1423-abaa-43e2-b4aa-cb708c03ee8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-361e1423-abaa-43e2-b4aa-cb708c03ee8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

